### PR TITLE
rename to LRTesteR

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,4 @@
-^MLTesteR\.Rproj$
+^LRTesteR\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE\.md$
 ^README\.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
-Package: MLTesteR
-Title: Hypothesis Tests Based on Maximum Likelihood Theory
+Package: LRTesteR
+Title: Likelihood Ratio Tests
 Version: 0.1
 Author: Greg McMahan
 Maintainer: Greg McMahan <gmcmacran@gmail.com>
-Description: Implements likelihood ration, score and wald tests for many distributions.
+Description: A collection of hypothesis tests based on the likelihood ratio.
 License: GPL-3
 Encoding: UTF-8
 LazyData: true

--- a/LRTesteR.Rproj
+++ b/LRTesteR.Rproj
@@ -1,7 +1,7 @@
 Version: 1.0
 
-RestoreWorkspace: No
-SaveWorkspace: No
+RestoreWorkspace: Default
+SaveWorkspace: Default
 AlwaysSaveHistory: Default
 
 EnableCodeIndexing: Yes
@@ -12,11 +12,6 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
-AutoAppendNewline: Yes
-StripTrailingWhitespace: Yes
-LineEndingConversion: Posix
-
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
-PackageRoxygenize: rd,collate,namespace

--- a/R/beta_tests.R
+++ b/R/beta_tests.R
@@ -10,7 +10,7 @@
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)
@@ -122,7 +122,7 @@ beta_shape1_lr_test <- function(x, shape1 = 1, alternative = "two.sided") {
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)

--- a/R/binomial_tests.R
+++ b/R/binomial_tests.R
@@ -11,7 +11,7 @@
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true. 52 successes. 100 trials
 #' binomial_p_lr_test(52, 100, .50, "two.sided")

--- a/R/exponential_tests.R
+++ b/R/exponential_tests.R
@@ -10,7 +10,7 @@
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)

--- a/R/gamma_tests.R
+++ b/R/gamma_tests.R
@@ -10,7 +10,7 @@
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)
@@ -114,7 +114,7 @@ gamma_shape_lr_test <- function(x, shape = 1, alternative = "two.sided") {
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)
@@ -230,7 +230,7 @@ gamma_scale_lr_test <- function(x, scale = 1, alternative = "two.sided") {
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)

--- a/R/gaussian_tests.R
+++ b/R/gaussian_tests.R
@@ -10,7 +10,7 @@
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)
@@ -84,7 +84,7 @@ gaussian_mu_lr_test <- function(x, mu = 0, alternative = "two.sided") {
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)

--- a/R/geometric_tests.R
+++ b/R/geometric_tests.R
@@ -11,7 +11,7 @@
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true. Two failures before the 1st success.
 #' geometric_p_lr_test(2, .50, "two.sided")

--- a/R/negative_binomial_tests.R
+++ b/R/negative_binomial_tests.R
@@ -11,7 +11,7 @@
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true. 52 successes. 100 trials
 #' negative_binomial_p_lr_test(48, 52, .50, "two.sided")

--- a/R/poisson_tests.R
+++ b/R/poisson_tests.R
@@ -10,7 +10,7 @@
 #'
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
-#' library(MLTesteR)
+#' library(LRTesteR)
 #'
 #' # Null is true
 #' set.seed(1)

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,12 +13,12 @@ knitr::opts_chunk$set(
 )
 ```
 
-# MLTesteR
+# LRTesteR
 
 <!-- badges: start -->
-[![R build status](https://github.com/gmcmacran/MLTesteR/workflows/R-CMD-check/badge.svg)](https://github.com/gmcmacran/MLTesteR/actions)
-[![Codecov test coverage](https://codecov.io/gh/gmcmacran/MLTesteR/branch/main/graph/badge.svg)](https://codecov.io/gh/gmcmacran/MLTesteR?branch=main)
-[![CRAN status](https://www.r-pkg.org/badges/version/MLTesteR)](https://cran.r-project.org/package=MLTesteR)
+[![R build status](https://github.com/gmcmacran/LRTesteR/workflows/R-CMD-check/badge.svg)](https://github.com/gmcmacran/LRTesteR/actions)
+[![Codecov test coverage](https://codecov.io/gh/gmcmacran/LRTesteR/branch/main/graph/badge.svg)](https://codecov.io/gh/gmcmacran/LRTesteR?branch=main)
+[![CRAN status](https://www.r-pkg.org/badges/version/LRTesteR)](https://cran.r-project.org/package=LRTesteR)
 <!-- badges: end -->
 
 LRTester implements the likelihood ratio test for many common distributions. All tests rely on chi square approximation even when exact sampling distributions are known. Tests require a sample size of at least 50.
@@ -28,7 +28,7 @@ A simulation that estimates asymptotic type I and type II error rates can be fou
 # Test mu of a gaussian distribution. 
 
 ```{r example}
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# MLTesteR
+# LRTesteR
 
 <!-- badges: start -->
 
 [![R build
-status](https://github.com/gmcmacran/MLTesteR/workflows/R-CMD-check/badge.svg)](https://github.com/gmcmacran/MLTesteR/actions)
+status](https://github.com/gmcmacran/LRTesteR/workflows/R-CMD-check/badge.svg)](https://github.com/gmcmacran/LRTesteR/actions)
 [![Codecov test
-coverage](https://codecov.io/gh/gmcmacran/MLTesteR/branch/main/graph/badge.svg)](https://codecov.io/gh/gmcmacran/MLTesteR?branch=main)
+coverage](https://codecov.io/gh/gmcmacran/LRTesteR/branch/main/graph/badge.svg)](https://codecov.io/gh/gmcmacran/LRTesteR?branch=main)
 [![CRAN
-status](https://www.r-pkg.org/badges/version/MLTesteR)](https://cran.r-project.org/package=MLTesteR)
+status](https://www.r-pkg.org/badges/version/LRTesteR)](https://cran.r-project.org/package=LRTesteR)
 <!-- badges: end -->
 
 LRTester implements the likelihood ratio test for many common
@@ -24,7 +24,7 @@ can be found [here](https://github.com/gmcmacran/TypeOneTypeTwoSim).
 # Test mu of a gaussian distribution.
 
 ``` r
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/beta_shape1_lr_test.Rd
+++ b/man/beta_shape1_lr_test.Rd
@@ -27,7 +27,7 @@ Test the shape1 parameter of a beta distribution using the likelihood ratio test
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/beta_shape2_lr_test.Rd
+++ b/man/beta_shape2_lr_test.Rd
@@ -27,7 +27,7 @@ Test the shape2 parameter of a beta distribution using the likelihood ratio test
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/binomial_p_lr_test.Rd
+++ b/man/binomial_p_lr_test.Rd
@@ -29,7 +29,7 @@ Test p of a binomial distribution using the likelihood ratio test.
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true. 52 successes. 100 trials
 binomial_p_lr_test(52, 100, .50, "two.sided")

--- a/man/exponentail_rate_lr_test.Rd
+++ b/man/exponentail_rate_lr_test.Rd
@@ -27,7 +27,7 @@ Test the rate of a exponential distribution using the likelihood ratio test.
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/gamma_rate_lr_test.Rd
+++ b/man/gamma_rate_lr_test.Rd
@@ -27,7 +27,7 @@ Test the rate parameter of a gamma distribution using the likelihood ratio test.
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/gamma_scale_lr_test.Rd
+++ b/man/gamma_scale_lr_test.Rd
@@ -27,7 +27,7 @@ Test the scale parameter of a gamma distribution using the likelihood ratio test
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/gamma_shape_lr_test.Rd
+++ b/man/gamma_shape_lr_test.Rd
@@ -27,7 +27,7 @@ Test the shape parameter of a gamma distribution using the likelihood ratio test
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/gaussian_mu_lr_test.Rd
+++ b/man/gaussian_mu_lr_test.Rd
@@ -27,7 +27,7 @@ Test the mean of a gaussian distribution using the likelihood ratio test.
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/gaussian_variance_lr_test.Rd
+++ b/man/gaussian_variance_lr_test.Rd
@@ -27,7 +27,7 @@ Test the variance of a gaussian distribution using the likelihood ratio test.
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/man/geometric_p_lr_test.Rd
+++ b/man/geometric_p_lr_test.Rd
@@ -28,7 +28,7 @@ Simulation shows this test needs the hypothesized p at or above .35 for a
 reasonable type I error.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true. Two failures before the 1st success.
 geometric_p_lr_test(2, .50, "two.sided")

--- a/man/negative_binomial_p_lr_test.Rd
+++ b/man/negative_binomial_p_lr_test.Rd
@@ -34,7 +34,7 @@ Test p of a negative binomial distribution using the likelihood ratio test.
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true. 52 successes. 100 trials
 negative_binomial_p_lr_test(48, 52, .50, "two.sided")

--- a/man/poisson_lambda_lr_test.Rd
+++ b/man/poisson_lambda_lr_test.Rd
@@ -27,7 +27,7 @@ Test lambda of a poisson distribution using the likelihood ratio test.
 This test requires a large sample size for approximation to be accurate.
 }
 \examples{
-library(MLTesteR)
+library(LRTesteR)
 
 # Null is true
 set.seed(1)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
-library(MLTesteR)
+library(LRTesteR)
 
-test_check("MLTesteR")
+test_check("LRTesteR")


### PR DESCRIPTION
This pull request handles all the details for a name change from MLTesteR to LRTesteR.

Change description.
Change library loading in examples.
Change library loading in tests.
Change project file.
Change readme.