### PR TITLE
import to suggest

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,10 +8,10 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Imports: 
-    stats,
-    EnvStats,
-    testthat
+    stats
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1
 Suggests: 
-    covr
+    covr,
+    EnvStats,
+    testthat


### PR DESCRIPTION
This pull request moves testthat and EnvStats from imports to suggest section of the description file. This fixes the note in github action's check.