### PR TITLE
Confidence Interval for function factory tests

### DIFF
--- a/R/a_function_factories.R
+++ b/R/a_function_factories.R
@@ -32,17 +32,17 @@ create_test_function_continuous <- function(calc_test_stat, p0, LB = -Inf) {
   if (!is.numeric(LB)) {
     stop("LB should be numeric.")
   }
-  
+
   calc_CI <- function(x, alternative, conf.level) {
     alpha <- 1 - conf.level
-    
+
     calc_left_side_CI <- function(alpha) {
       helper <- function(param) {
         W <- calc_test_stat(x, param, "less")
         out <- W - stats::qnorm(p = alpha, lower.tail = FALSE)
         return(out)
       }
-      out <- stats::uniroot(helper, lower = pmax(-9999999, LB), upper = 9999999, tol = .Machine$double.eps^.50)$root
+      out <- stats::uniroot(helper, lower = pmax(-9999999, LB + .Machine$double.eps), upper = 9999999, tol = .Machine$double.eps^.50)$root
       return(out)
     }
     calc_right_side_CI <- function(alpha) {
@@ -51,10 +51,10 @@ create_test_function_continuous <- function(calc_test_stat, p0, LB = -Inf) {
         out <- W - stats::qnorm(p = alpha, lower.tail = TRUE)
         return(out)
       }
-      out <- stats::uniroot(helper, lower = pmax(-9999999, LB), upper = 9999999, tol = .Machine$double.eps^.50)$root
+      out <- stats::uniroot(helper, lower = pmax(-9999999, LB + 10 * .Machine$double.eps), upper = 9999999, tol = .Machine$double.eps^.50)$root
       return(out)
     }
-    
+
     if (alternative == "two.sided") {
       alpha <- alpha / 2
       CI <- c(calc_left_side_CI(alpha), calc_right_side_CI(alpha))
@@ -65,7 +65,7 @@ create_test_function_continuous <- function(calc_test_stat, p0, LB = -Inf) {
     else {
       CI <- c(calc_left_side_CI(alpha), Inf)
     }
-    
+
     return(CI)
   }
 
@@ -120,7 +120,7 @@ create_test_function_continuous <- function(calc_test_stat, p0, LB = -Inf) {
     else {
       p.value <- stats::pnorm(q = W, lower.tail = FALSE)
     }
-    
+
     CI <- calc_CI(x, alternative, conf.level)
 
     out <- list(statistic = W, p.value = p.value, CI = CI, alternative = alternative)

--- a/R/a_function_factories.R
+++ b/R/a_function_factories.R
@@ -1,6 +1,6 @@
 # fix check.
 # Not actually global.
-utils::globalVariables(c("x", "alternative"))
+utils::globalVariables(c("x", "alternative", "conf.level"))
 
 #' @keywords internal
 #' A function factory

--- a/R/beta_tests.R
+++ b/R/beta_tests.R
@@ -51,12 +51,10 @@ calc_test_stat_beta_shape1 <- function(x, shape1, alternative) {
 
 #' Test the shape1 parameter of a beta distribution using the likelihood ratio test.
 #'
-#' @param x a (non-empty) numeric vector of data values.
+#' @inheritParams gaussian_mu_lr_test
 #' @param shape1 a number indicating the tested value of the shape1 parameter.
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
-#' hypothesis.
-#' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
+#' @inherit gaussian_mu_lr_test return
+#' @inherit gaussian_mu_lr_test source
 #' @examples
 #' library(LRTesteR)
 #'
@@ -124,12 +122,10 @@ calc_test_stat_beta_shape2 <- function(x, shape2, alternative) {
 
 #' Test the shape2 parameter of a beta distribution using the likelihood ratio test.
 #'
-#' @param x a (non-empty) numeric vector of data values.
+#' @inheritParams gaussian_mu_lr_test
 #' @param shape2 a number indicating the tested value of the shape2 parameter.
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
-#' hypothesis.
-#' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
+#' @inherit gaussian_mu_lr_test return
+#' @inherit gaussian_mu_lr_test source
 #' @examples
 #' library(LRTesteR)
 #'

--- a/R/exponential_tests.R
+++ b/R/exponential_tests.R
@@ -14,12 +14,10 @@ calc_test_stat_exponentail_rate <- function(x, rate, alternative) {
 
 #' Test the rate of a exponential distribution using the likelihood ratio test.
 #'
-#' @param x a (non-empty) numeric vector of data values.
+#' @inheritParams gaussian_mu_lr_test
 #' @param rate a number indicating the tested value of rate.
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
-#' hypothesis.
-#' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
+#' @inherit gaussian_mu_lr_test return
+#' @inherit gaussian_mu_lr_test source
 #' @examples
 #' library(LRTesteR)
 #'

--- a/R/gamma_tests.R
+++ b/R/gamma_tests.R
@@ -39,12 +39,10 @@ calc_test_stat_gamma_shape <- function(x, shape, alternative) {
 
 #' Test the shape parameter of a gamma distribution using the likelihood ratio test.
 #'
-#' @param x a (non-empty) numeric vector of data values.
+#' @inheritParams gaussian_mu_lr_test
 #' @param shape a number indicating the tested value of the shape parameter.
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
-#' hypothesis.
-#' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
+#' @inherit gaussian_mu_lr_test return
+#' @inherit gaussian_mu_lr_test source
 #' @examples
 #' library(LRTesteR)
 #'
@@ -99,7 +97,7 @@ calc_test_stat_gamma_scale <- function(x, scale, alternative) {
     return(profile_shape)
   }
 
-  profile_shape <- get_profile_shape(x, scale)
+  profile_shape <- get_profile_shape(x, obs_shape)
 
   W <- 2 * (sum(stats::dgamma(x = x, shape = obs_shape, scale = obs_scale, log = TRUE)) -
     sum(stats::dgamma(x = x, shape = profile_shape, scale = scale, log = TRUE)))
@@ -113,12 +111,10 @@ calc_test_stat_gamma_scale <- function(x, scale, alternative) {
 
 #' Test the scale parameter of a gamma distribution using the likelihood ratio test.
 #'
-#' @param x a (non-empty) numeric vector of data values.
+#' @inheritParams gaussian_mu_lr_test
 #' @param scale a number indicating the tested value of the scale parameter.
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
-#' hypothesis.
-#' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
+#' @inherit gaussian_mu_lr_test return
+#' @inherit gaussian_mu_lr_test source
 #' @examples
 #' library(LRTesteR)
 #'
@@ -188,12 +184,10 @@ calc_test_stat_gamma_rate <- function(x, rate, alternative) {
 
 #' Test the rate parameter of a gamma distribution using the likelihood ratio test.
 #'
-#' @param x a (non-empty) numeric vector of data values.
+#' @inheritParams gaussian_mu_lr_test
 #' @param rate a number indicating the tested value of the rate parameter.
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
-#' hypothesis.
-#' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
+#' @inherit gaussian_mu_lr_test return
+#' @inherit gaussian_mu_lr_test source
 #' @examples
 #' library(LRTesteR)
 #'

--- a/R/gaussian_tests.R
+++ b/R/gaussian_tests.R
@@ -20,7 +20,8 @@ calc_test_stat_normal_mu <- function(x, mu, alternative) {
 #' @param x a (non-empty) numeric vector of data values.
 #' @param mu a number indicating the tested value of mu.
 #' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
+#' @param conf.level confidence level of the likelihood interval.
+#' @return An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 #' hypothesis.
 #' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 #' @examples
@@ -55,12 +56,10 @@ calc_test_stat_normal_sigma.squared <- function(x, sigma.squared, alternative) {
 
 #' Test the variance of a gaussian distribution using the likelihood ratio test.
 #'
-#' @param x a (non-empty) numeric vector of data values.
+#' @inheritParams gaussian_mu_lr_test
 #' @param sigma.squared a number indicating the tested value of sigma squared.
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
-#' hypothesis.
-#' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
+#' @inherit gaussian_mu_lr_test return
+#' @inherit gaussian_mu_lr_test source
 #' @examples
 #' library(LRTesteR)
 #'

--- a/R/poisson_tests.R
+++ b/R/poisson_tests.R
@@ -14,12 +14,10 @@ calc_test_stat_poisson_lambda <- function(x, lambda, alternative) {
 
 #' Test lambda of a poisson distribution using the likelihood ratio test.
 #'
-#' @param x a (non-empty) numeric vector of data values.
+#' @inheritParams gaussian_mu_lr_test
 #' @param lambda a number indicating the tested value of lambda
-#' @param alternative a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".
-#' @return An S3 class containing the test statistic, p value and alternative
-#' hypothesis.
-#' @source \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
+#' @inherit gaussian_mu_lr_test return
+#' @inherit gaussian_mu_lr_test source
 #' @examples
 #' library(LRTesteR)
 #'

--- a/man/beta_shape1_lr_test.Rd
+++ b/man/beta_shape1_lr_test.Rd
@@ -7,7 +7,7 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-beta_shape1_lr_test(x, shape1, alternative = "two.sided")
+beta_shape1_lr_test(x, shape1, alternative = "two.sided", conf.level = 0.95)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +15,11 @@ beta_shape1_lr_test(x, shape1, alternative = "two.sided")
 \item{shape1}{a number indicating the tested value of the shape1 parameter.}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/man/beta_shape2_lr_test.Rd
+++ b/man/beta_shape2_lr_test.Rd
@@ -7,7 +7,7 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-beta_shape2_lr_test(x, shape2, alternative = "two.sided")
+beta_shape2_lr_test(x, shape2, alternative = "two.sided", conf.level = 0.95)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +15,11 @@ beta_shape2_lr_test(x, shape2, alternative = "two.sided")
 \item{shape2}{a number indicating the tested value of the shape2 parameter.}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/man/exponentail_rate_lr_test.Rd
+++ b/man/exponentail_rate_lr_test.Rd
@@ -7,7 +7,7 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-exponentail_rate_lr_test(x, rate, alternative = "two.sided")
+exponentail_rate_lr_test(x, rate, alternative = "two.sided", conf.level = 0.95)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +15,11 @@ exponentail_rate_lr_test(x, rate, alternative = "two.sided")
 \item{rate}{a number indicating the tested value of rate.}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/man/gamma_rate_lr_test.Rd
+++ b/man/gamma_rate_lr_test.Rd
@@ -7,7 +7,7 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-gamma_rate_lr_test(x, rate, alternative = "two.sided")
+gamma_rate_lr_test(x, rate, alternative = "two.sided", conf.level = 0.95)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +15,11 @@ gamma_rate_lr_test(x, rate, alternative = "two.sided")
 \item{rate}{a number indicating the tested value of the rate parameter.}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/man/gamma_scale_lr_test.Rd
+++ b/man/gamma_scale_lr_test.Rd
@@ -7,7 +7,7 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-gamma_scale_lr_test(x, scale, alternative = "two.sided")
+gamma_scale_lr_test(x, scale, alternative = "two.sided", conf.level = 0.95)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +15,11 @@ gamma_scale_lr_test(x, scale, alternative = "two.sided")
 \item{scale}{a number indicating the tested value of the scale parameter.}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/man/gamma_shape_lr_test.Rd
+++ b/man/gamma_shape_lr_test.Rd
@@ -7,7 +7,7 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-gamma_shape_lr_test(x, shape, alternative = "two.sided")
+gamma_shape_lr_test(x, shape, alternative = "two.sided", conf.level = 0.95)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +15,11 @@ gamma_shape_lr_test(x, shape, alternative = "two.sided")
 \item{shape}{a number indicating the tested value of the shape parameter.}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/man/gaussian_mu_lr_test.Rd
+++ b/man/gaussian_mu_lr_test.Rd
@@ -7,7 +7,7 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-gaussian_mu_lr_test(x, mu, alternative = "two.sided")
+gaussian_mu_lr_test(x, mu, alternative = "two.sided", conf.level = 0.95)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +15,11 @@ gaussian_mu_lr_test(x, mu, alternative = "two.sided")
 \item{mu}{a number indicating the tested value of mu.}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/man/gaussian_variance_lr_test.Rd
+++ b/man/gaussian_variance_lr_test.Rd
@@ -7,7 +7,12 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-gaussian_variance_lr_test(x, sigma.squared, alternative = "two.sided")
+gaussian_variance_lr_test(
+  x,
+  sigma.squared,
+  alternative = "two.sided",
+  conf.level = 0.95
+)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +20,11 @@ gaussian_variance_lr_test(x, sigma.squared, alternative = "two.sided")
 \item{sigma.squared}{a number indicating the tested value of sigma squared.}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/man/poisson_lambda_lr_test.Rd
+++ b/man/poisson_lambda_lr_test.Rd
@@ -7,7 +7,7 @@
 \url{https://en.wikipedia.org/wiki/Likelihood-ratio_test}
 }
 \usage{
-poisson_lambda_lr_test(x, lambda, alternative = "two.sided")
+poisson_lambda_lr_test(x, lambda, alternative = "two.sided", conf.level = 0.95)
 }
 \arguments{
 \item{x}{a (non-empty) numeric vector of data values.}
@@ -15,9 +15,11 @@ poisson_lambda_lr_test(x, lambda, alternative = "two.sided")
 \item{lambda}{a number indicating the tested value of lambda}
 
 \item{alternative}{a character string specifying the alternative hypothesis, must be one of "two.sided" (default), "greater" or "less".}
+
+\item{conf.level}{confidence level of the likelihood interval.}
 }
 \value{
-An S3 class containing the test statistic, p value and alternative
+An S3 class containing the test statistic, p value, likelihood based confidence interval, and alternative
 hypothesis.
 }
 \description{

--- a/tests/testthat/test_a_function_factories.R
+++ b/tests/testthat/test_a_function_factories.R
@@ -5,7 +5,7 @@ for (alt in c("two.sided", "greater", "less")) {
   f <- LRTesteR:::create_test_function_continuous(LRTesteR:::calc_test_stat_normal_mu, mu)
   test_that("Check structure.", {
     expect_true(class(f) == "function")
-    expect_true(all(names(formals(f)) == c("x", "mu", "alternative")))
+    expect_true(all(names(formals(f)) == c("x", "mu", "alternative", "conf.level")))
   })
 }
 rm(f)

--- a/tests/testthat/test_exponential_tests.R
+++ b/tests/testthat/test_exponential_tests.R
@@ -38,8 +38,8 @@ for (alt in c("two.sided", "greater", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_02 <- exact_test(x, 1, alt)
@@ -47,6 +47,15 @@ for (alt in c("two.sided", "greater", "less")) {
     expect_true(test$p.value > .05)
     expect_true(abs(test$p.value - test_02$p.value) < .02)
   })
+
+  # .0499 instead of .05 b/c of floating point error associated with convergence.
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  test_that("Check CI", {
+    expect_true(ifelse(is.finite(CI1), exponentail_rate_lr_test(x, CI1, alt)$p.value, .05) >= .0499)
+    expect_true(ifelse(is.finite(CI2), exponentail_rate_lr_test(x, CI2, alt)$p.value, .05) >= .0499)
+  })
+  rm(CI1, CI2)
 }
 
 ###############################################
@@ -59,8 +68,8 @@ for (alt in c("two.sided", "greater")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_02 <- exact_test(x, 1, alt)
@@ -68,6 +77,17 @@ for (alt in c("two.sided", "greater")) {
     expect_true(test$p.value <= .05)
     expect_true(abs(test$p.value - test_02$p.value) < .01)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), exponentail_rate_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), exponentail_rate_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 for (alt in c("two.sided", "less")) {
@@ -77,8 +97,8 @@ for (alt in c("two.sided", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_02 <- exact_test(x, 3, alt)
@@ -86,6 +106,17 @@ for (alt in c("two.sided", "less")) {
     expect_true(test$p.value <= .05)
     expect_true(abs(test$p.value - test_02$p.value) < .01)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), exponentail_rate_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), exponentail_rate_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 ###############################################
@@ -109,4 +140,12 @@ test_that("alternative input checking works", {
   expect_error(exponentail_rate_lr_test(rexp(50), 1, c("two.sided", "less")), "Argument alternative should have length one.")
   expect_error(exponentail_rate_lr_test(rexp(50), 1, 1), "Argument alternative should be a character.")
   expect_error(exponentail_rate_lr_test(rexp(50), 1, "lesss"), "Argument alternative should be 'two.sided', 'less', or 'greater.")
+})
+
+set.seed(1)
+test_that("alternative input checking works", {
+  expect_error(exponentail_rate_lr_test(rexp(50), 1, "less", c(.50, .75)), "conf.level should have length one.")
+  expect_error(exponentail_rate_lr_test(rexp(50), 1, "less", "foo"), "conf.level should be numeric.")
+  expect_error(exponentail_rate_lr_test(rexp(50), 1, "less", 0), "conf.level should between zero and one.")
+  expect_error(exponentail_rate_lr_test(rexp(50), 1, "less", 1), "conf.level should between zero and one.")
 })

--- a/tests/testthat/test_gamma_tests.R
+++ b/tests/testthat/test_gamma_tests.R
@@ -8,13 +8,22 @@ for (alt in c("two.sided", "greater", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value > .05)
   })
+
+  # .0499 instead of .05 b/c of floating point error associated with convergence.
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  test_that("Check CI", {
+    expect_true(ifelse(is.finite(CI1), gamma_shape_lr_test(x, CI1, alt)$p.value, .05) >= .0499)
+    expect_true(ifelse(is.finite(CI2), gamma_shape_lr_test(x, CI2, alt)$p.value, .05) >= .0499)
+  })
+  rm(CI1, CI2)
 }
 
 ###############################################
@@ -27,13 +36,24 @@ for (alt in c("two.sided", "greater")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value <= .05)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gamma_shape_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gamma_shape_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 for (alt in c("two.sided", "less")) {
@@ -43,13 +63,24 @@ for (alt in c("two.sided", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value <= .05)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gamma_shape_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gamma_shape_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 ###############################################
@@ -75,23 +106,40 @@ test_that("alternative input checking works", {
   expect_error(gamma_shape_lr_test(rgamma(50, shape = 1), 1, "lesss"), "Argument alternative should be 'two.sided', 'less', or 'greater.")
 })
 
+set.seed(1)
+test_that("alternative input checking works", {
+  expect_error(gamma_shape_lr_test(rgamma(50, shape = 1), 1, "less", c(.50, .75)), "conf.level should have length one.")
+  expect_error(gamma_shape_lr_test(rgamma(50, shape = 1), 1, "less", "foo"), "conf.level should be numeric.")
+  expect_error(gamma_shape_lr_test(rgamma(50, shape = 1), 1, "less", 0), "conf.level should between zero and one.")
+  expect_error(gamma_shape_lr_test(rgamma(50, shape = 1), 1, "less", 1), "conf.level should between zero and one.")
+})
+
 ###############################################
 # Null True
 ###############################################
 for (alt in c("two.sided", "greater", "less")) {
-  set.seed(5)
-  x <- rgamma(n = 100, shape = 10, scale = 1)
+  set.seed(1)
+  x <- rgamma(n = 100, shape = 1, scale = 1)
   test <- gamma_scale_lr_test(x, 1, alt)
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value > .05)
   })
+
+  # .0499 instead of .05 b/c of floating point error associated with convergence.
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  test_that("Check CI", {
+    expect_true(ifelse(is.finite(CI1), gamma_scale_lr_test(x, CI1, alt)$p.value, .05) >= .0499)
+    expect_true(ifelse(is.finite(CI2), gamma_scale_lr_test(x, CI2, alt)$p.value, .05) >= .0499)
+  })
+  rm(CI1, CI2)
 }
 
 ###############################################
@@ -104,13 +152,24 @@ for (alt in c("two.sided", "greater")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value <= .05)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gamma_scale_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gamma_scale_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 for (alt in c("two.sided", "less")) {
@@ -120,13 +179,24 @@ for (alt in c("two.sided", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value <= .05)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gamma_scale_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gamma_scale_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 ###############################################
@@ -152,6 +222,14 @@ test_that("alternative input checking works", {
   expect_error(gamma_scale_lr_test(rgamma(50, shape = 1), 1, "lesss"), "Argument alternative should be 'two.sided', 'less', or 'greater.")
 })
 
+set.seed(1)
+test_that("alternative input checking works", {
+  expect_error(gamma_scale_lr_test(rgamma(50, shape = 1), 1, "less", c(.50, .75)), "conf.level should have length one.")
+  expect_error(gamma_scale_lr_test(rgamma(50, shape = 1), 1, "less", "foo"), "conf.level should be numeric.")
+  expect_error(gamma_scale_lr_test(rgamma(50, shape = 1), 1, "less", 0), "conf.level should between zero and one.")
+  expect_error(gamma_scale_lr_test(rgamma(50, shape = 1), 1, "less", 1), "conf.level should between zero and one.")
+})
+
 ###############################################
 # Null True
 ###############################################
@@ -162,13 +240,22 @@ for (alt in c("two.sided", "greater", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value > .05)
   })
+
+  # .0499 instead of .05 b/c of floating point error associated with convergence.
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  test_that("Check CI", {
+    expect_true(ifelse(is.finite(CI1), gamma_rate_lr_test(x, CI1, alt)$p.value, .05) >= .0499)
+    expect_true(ifelse(is.finite(CI2), gamma_rate_lr_test(x, CI2, alt)$p.value, .05) >= .0499)
+  })
+  rm(CI1, CI2)
 }
 
 ###############################################
@@ -181,13 +268,24 @@ for (alt in c("two.sided", "greater")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value <= .05)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gamma_rate_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gamma_rate_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 for (alt in c("two.sided", "less")) {
@@ -197,13 +295,24 @@ for (alt in c("two.sided", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   test_that("Check contents", {
     expect_true(test$p.value <= .05)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gamma_rate_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gamma_rate_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 ###############################################
@@ -227,4 +336,12 @@ test_that("alternative input checking works", {
   expect_error(gamma_rate_lr_test(rgamma(50, shape = 1), 1, c("two.sided", "less")), "Argument alternative should have length one.")
   expect_error(gamma_rate_lr_test(rgamma(50, shape = 1), 1, 1), "Argument alternative should be a character.")
   expect_error(gamma_rate_lr_test(rgamma(50, shape = 1), 1, "lesss"), "Argument alternative should be 'two.sided', 'less', or 'greater.")
+})
+
+set.seed(1)
+test_that("alternative input checking works", {
+  expect_error(gamma_rate_lr_test(rgamma(50, shape = 1), 1, "less", c(.50, .75)), "conf.level should have length one.")
+  expect_error(gamma_rate_lr_test(rgamma(50, shape = 1), 1, "less", "foo"), "conf.level should be numeric.")
+  expect_error(gamma_rate_lr_test(rgamma(50, shape = 1), 1, "less", 0), "conf.level should between zero and one.")
+  expect_error(gamma_rate_lr_test(rgamma(50, shape = 1), 1, "less", 1), "conf.level should between zero and one.")
 })

--- a/tests/testthat/test_gaussian_tests.R
+++ b/tests/testthat/test_gaussian_tests.R
@@ -8,8 +8,8 @@ for (alt in c("two.sided", "greater", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   # Compare with t test
@@ -18,6 +18,15 @@ for (alt in c("two.sided", "greater", "less")) {
     expect_true(test$p.value > .05)
     expect_true(abs(test$p.value - test_02$p.value) < .01)
   })
+
+  # .0499 instead of .05 b/c of floating point error associated with convergence.
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  test_that("Check CI", {
+    expect_true(ifelse(is.finite(CI1), gaussian_mu_lr_test(x, CI1, alt)$p.value, .05) >= .0499)
+    expect_true(ifelse(is.finite(CI2), gaussian_mu_lr_test(x, CI2, alt)$p.value, .05) >= .0499)
+  })
+  rm(CI1, CI2)
 }
 
 ###############################################
@@ -30,8 +39,8 @@ for (alt in c("two.sided", "greater")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   # Compare with t test
@@ -40,6 +49,17 @@ for (alt in c("two.sided", "greater")) {
     expect_true(test$p.value <= .05)
     expect_true(abs(test$p.value - test_02$p.value) < .01)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gaussian_mu_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gaussian_mu_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 for (alt in c("two.sided", "less")) {
@@ -49,8 +69,8 @@ for (alt in c("two.sided", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   # Compare with t test
@@ -59,6 +79,17 @@ for (alt in c("two.sided", "less")) {
     expect_true(test$p.value <= .05)
     expect_true(abs(test$p.value - test_02$p.value) < .01)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gaussian_mu_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gaussian_mu_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 ###############################################
@@ -83,6 +114,14 @@ test_that("alternative input checking works", {
   expect_error(gaussian_mu_lr_test(rnorm(50), 0, "lesss"), "Argument alternative should be 'two.sided', 'less', or 'greater.")
 })
 
+set.seed(1)
+test_that("alternative input checking works", {
+  expect_error(gaussian_mu_lr_test(rnorm(50), 1, "less", c(.50, .75)), "conf.level should have length one.")
+  expect_error(gaussian_mu_lr_test(rnorm(50), 1, "less", "foo"), "conf.level should be numeric.")
+  expect_error(gaussian_mu_lr_test(rnorm(50), 1, "less", 0), "conf.level should between zero and one.")
+  expect_error(gaussian_mu_lr_test(rnorm(50), 1, "less", 1), "conf.level should between zero and one.")
+})
+
 ###############################################
 # Null True
 ###############################################
@@ -93,8 +132,8 @@ for (alt in c("two.sided", "greater", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   # Compare with chi square test for variance
@@ -115,8 +154,8 @@ for (alt in c("two.sided", "greater")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   # Compare with chi square test for variance
@@ -125,6 +164,17 @@ for (alt in c("two.sided", "greater")) {
     expect_true(test$p.value <= .05)
     expect_true(abs(test$p.value - test_02$p.value) < .01)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gaussian_variance_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gaussian_variance_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 for (alt in c("two.sided", "less")) {
@@ -134,8 +184,8 @@ for (alt in c("two.sided", "less")) {
 
   test_that("Check structure.", {
     expect_true(class(test) == "lrtest")
-    expect_true(length(test) == 3)
-    expect_true(all(names(test) == c("statistic", "p.value", "alternative")))
+    expect_true(length(test) == 4)
+    expect_true(all(names(test) == c("statistic", "p.value", "CI", "alternative")))
   })
 
   # Compare with chi square test for variance
@@ -144,6 +194,17 @@ for (alt in c("two.sided", "less")) {
     expect_true(test$p.value <= .05)
     expect_true(abs(test$p.value - test_02$p.value) < .01)
   })
+
+  CI1 <- test$CI[1] + .Machine$double.eps # Avoid boundary
+  CI2 <- test$CI[2] + .Machine$double.eps
+  pval <- pmin(
+    ifelse(is.finite(CI1), gaussian_variance_lr_test(x, CI1, alt)$p.value, .05),
+    ifelse(is.finite(CI2), gaussian_variance_lr_test(x, CI2, alt)$p.value, .05)
+  )
+  test_that("Check CI", {
+    expect_true(pval <= .0500001)
+  })
+  rm(CI1, CI2, pval)
 }
 
 ###############################################
@@ -167,4 +228,12 @@ test_that("alternative input checking works", {
   expect_error(gaussian_variance_lr_test(rnorm(50), 1, c("two.sided", "less")), "Argument alternative should have length one.")
   expect_error(gaussian_variance_lr_test(rnorm(50), 1, 1), "Argument alternative should be a character.")
   expect_error(gaussian_variance_lr_test(rnorm(50), 1, "lesss"), "Argument alternative should be 'two.sided', 'less', or 'greater.")
+})
+
+set.seed(1)
+test_that("alternative input checking works", {
+  expect_error(gaussian_variance_lr_test(rnorm(50), 1, "less", c(.50, .75)), "conf.level should have length one.")
+  expect_error(gaussian_variance_lr_test(rnorm(50), 1, "less", "foo"), "conf.level should be numeric.")
+  expect_error(gaussian_variance_lr_test(rnorm(50), 1, "less", 0), "conf.level should between zero and one.")
+  expect_error(gaussian_variance_lr_test(rnorm(50), 1, "less", 1), "conf.level should between zero and one.")
 })


### PR DESCRIPTION
The function factory now has likelihood based confidence intervals!

 Function documentation uses inheritance instead of repeating everything.

Binomial and negative binomial functions are not a part of the function factory and don't have confidence intervals yet. May make a second factory function for these two. May not. Left these functions as is (no CIs or doc changes). Branch already has a large scope.