### PR TITLE
fix profile shape argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Likelihood Ratio Tests
 Version: 0.2.1
 Author: Greg McMahan
 Maintainer: Greg McMahan <gmcmacran@gmail.com>
-Description: A collection of hypothesis tests based on the likelihood ratio
+Description: A collection of hypothesis tests and confidence intervals based on the likelihood ratio
     <https://en.wikipedia.org/wiki/Likelihood-ratio_test>.
 License: GPL-3
 Encoding: UTF-8

--- a/R/a_function_factories.R
+++ b/R/a_function_factories.R
@@ -42,7 +42,7 @@ create_test_function_continuous <- function(calc_test_stat, p0, LB = -Inf) {
         out <- W - stats::qnorm(p = alpha, lower.tail = FALSE)
         return(out)
       }
-      out <- stats::uniroot(helper, lower = pmax(-9999999, LB + .Machine$double.eps), upper = 9999999, tol = .Machine$double.eps^.50)$root
+      out <- stats::uniroot(helper, lower = pmax(-9999999, LB + 20 * .Machine$double.eps), upper = 9999999, tol = .Machine$double.eps^.50)$root
       return(out)
     }
     calc_right_side_CI <- function(alpha) {
@@ -51,7 +51,7 @@ create_test_function_continuous <- function(calc_test_stat, p0, LB = -Inf) {
         out <- W - stats::qnorm(p = alpha, lower.tail = TRUE)
         return(out)
       }
-      out <- stats::uniroot(helper, lower = pmax(-9999999, LB + 10 * .Machine$double.eps), upper = 9999999, tol = .Machine$double.eps^.50)$root
+      out <- stats::uniroot(helper, lower = pmax(-9999999, LB + 20 * .Machine$double.eps), upper = 9999999, tol = .Machine$double.eps^.50)$root
       return(out)
     }
 

--- a/R/gamma_tests.R
+++ b/R/gamma_tests.R
@@ -84,6 +84,7 @@ calc_test_stat_gamma_scale <- function(x, scale, alternative) {
   obs_scale <- 1 / obs_rate
 
   get_profile_shape <- function(x, scale) {
+    scale <- pmax(scale, .0000001) # Avoid underflow in bounds of search
     geo_mean <- function(x) {
       return(exp(mean(log(x))))
     }
@@ -97,7 +98,7 @@ calc_test_stat_gamma_scale <- function(x, scale, alternative) {
     return(profile_shape)
   }
 
-  profile_shape <- get_profile_shape(x, obs_shape)
+  profile_shape <- get_profile_shape(x, scale)
 
   W <- 2 * (sum(stats::dgamma(x = x, shape = obs_shape, scale = obs_scale, log = TRUE)) -
     sum(stats::dgamma(x = x, shape = profile_shape, scale = scale, log = TRUE)))
@@ -157,6 +158,7 @@ calc_test_stat_gamma_rate <- function(x, rate, alternative) {
 
   get_profile_shape <- function(x, rate) {
     scale <- 1 / rate
+    scale <- pmax(scale, .0000001) # Avoid underflow in bounds of search
     geo_mean <- function(x) {
       return(exp(mean(log(x))))
     }


### PR DESCRIPTION
Changes are:

1: argument in profile_shape <- get_profile_shape(x, obs_shape) to profile_shape <- get_profile_shape(x, scale)
2: scale <- pmax(scale, .0000001) to avoid underflow.
3: Change description to reflect CI functionality.