### PR TITLE
Beta mle optimize

### DIFF
--- a/R/beta_tests.R
+++ b/R/beta_tests.R
@@ -1,26 +1,37 @@
 #' @keywords internal
 calc_test_stat_beta_shape1 <- function(x, shape1, alternative) {
   get_MLEs <- function(x) {
-    neg_log_likelihood <- function(MLEs) {
-      est_shape1 <- pmax(MLEs[1], .0001)
-      est_shape2 <- pmax(MLEs[2], .0001)
-
-      objective <- -1 * sum(stats::dbeta(x = x, shape1 = est_shape1, shape2 = est_shape2, log = TRUE))
-
-      return(objective)
-    }
-
     # starting points (method of moments)
     xbar <- base::mean(x)
     vbar <- stats::var(x)
     C <- (xbar * (1 - xbar)) / vbar - 1
     shape1_start <- xbar * C
     shape2_start <- (1 - xbar) * C
-    MLEstart <- c(shape1_start, shape2_start)
+    MLE <- matrix(c(shape1_start, shape2_start), nrow = 2, ncol = 1, byrow = TRUE)
     rm(xbar, vbar, C, shape1_start, shape2_start)
 
-    MLEs <- stats::optim(MLEstart, neg_log_likelihood, lower = .Machine$double.eps, method = "L-BFGS-B", control = list(factr = 1e4))$par
-    return(MLEs)
+    # newtons method
+    # page 9
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      g1 <- base::digamma(MLE[1]) - base::digamma(MLE[1] + MLE[2]) - sum(log(x)) / length(x) # eq 2.6
+      g2 <- base::digamma(MLE[2]) - base::digamma(MLE[1] + MLE[2]) - sum(log(1 - x)) / length(x) # eq 2.7
+      g <- matrix(c(g1, g2), nrow = 2, ncol = 1, byrow = TRUE)
+
+      dg1dshape1 <- base::trigamma(MLE[1]) - base::trigamma(MLE[1] + MLE[2]) # eq 2.8
+      dg1dshape2 <- -1 * base::trigamma(MLE[1] + MLE[2]) # eq 2.9
+      dg2dshape2 <- base::trigamma(MLE[2]) - base::trigamma(MLE[1] + MLE[2]) # eq 2.10
+      G <- matrix(c(dg1dshape1, dg1dshape2, dg1dshape2, dg2dshape2), nrow = 2, ncol = 2, byrow = TRUE)
+
+      MLE_new <- MLE - solve(G) %*% g
+      tol <- max(abs(MLE - MLE_new))
+      counter <- counter + 1
+      MLE <- MLE_new
+    }
+
+    MLE <- as.vector(MLE)
+    return(MLE)
   }
   MLEs <- get_MLEs(x)
   obs_shape1 <- MLEs[1]
@@ -75,26 +86,37 @@ beta_shape1_one_sample <- LRTesteR:::create_test_function_one_sample_case_one(LR
 #' @keywords internal
 calc_test_stat_beta_shape2 <- function(x, shape2, alternative) {
   get_MLEs <- function(x) {
-    neg_log_likelihood <- function(MLEs) {
-      est_shape1 <- pmax(MLEs[1], .0001)
-      est_shape2 <- pmax(MLEs[2], .0001)
-
-      objective <- -1 * sum(stats::dbeta(x = x, shape1 = est_shape1, shape2 = est_shape2, log = TRUE))
-
-      return(objective)
-    }
-
     # starting points (method of moments)
     xbar <- base::mean(x)
     vbar <- stats::var(x)
     C <- (xbar * (1 - xbar)) / vbar - 1
     shape1_start <- xbar * C
     shape2_start <- (1 - xbar) * C
-    MLEstart <- c(shape1_start, shape2_start)
+    MLE <- matrix(c(shape1_start, shape2_start), nrow = 2, ncol = 1, byrow = TRUE)
     rm(xbar, vbar, C, shape1_start, shape2_start)
 
-    MLEs <- stats::optim(MLEstart, neg_log_likelihood, lower = .Machine$double.eps, method = "L-BFGS-B", control = list(factr = 1e4))$par
-    return(MLEs)
+    # newtons method
+    # page 9
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      g1 <- base::digamma(MLE[1]) - base::digamma(MLE[1] + MLE[2]) - sum(log(x)) / length(x) # eq 2.6
+      g2 <- base::digamma(MLE[2]) - base::digamma(MLE[1] + MLE[2]) - sum(log(1 - x)) / length(x) # eq 2.7
+      g <- matrix(c(g1, g2), nrow = 2, ncol = 1, byrow = TRUE)
+
+      dg1dshape1 <- base::trigamma(MLE[1]) - base::trigamma(MLE[1] + MLE[2]) # eq 2.8
+      dg1dshape2 <- -1 * base::trigamma(MLE[1] + MLE[2]) # eq 2.9
+      dg2dshape2 <- base::trigamma(MLE[2]) - base::trigamma(MLE[1] + MLE[2]) # eq 2.10
+      G <- matrix(c(dg1dshape1, dg1dshape2, dg1dshape2, dg2dshape2), nrow = 2, ncol = 2, byrow = TRUE)
+
+      MLE_new <- MLE - solve(G) %*% g
+      tol <- max(abs(MLE - MLE_new))
+      counter <- counter + 1
+      MLE <- MLE_new
+    }
+
+    MLE <- as.vector(MLE)
+    return(MLE)
   }
   MLEs <- get_MLEs(x)
   obs_shape1 <- MLEs[1]
@@ -149,26 +171,37 @@ beta_shape2_one_sample <- LRTesteR:::create_test_function_one_sample_case_one(LR
 calc_test_stat_beta_shape1_one_way <- function(x, fctr) {
   # null
   get_MLEs <- function(x) {
-    neg_log_likelihood <- function(MLEs) {
-      est_shape1 <- pmax(MLEs[1], .0001)
-      est_shape2 <- pmax(MLEs[2], .0001)
-
-      objective <- -1 * sum(stats::dbeta(x = x, shape1 = est_shape1, shape2 = est_shape2, log = TRUE))
-
-      return(objective)
-    }
-
     # starting points (method of moments)
     xbar <- base::mean(x)
     vbar <- stats::var(x)
     C <- (xbar * (1 - xbar)) / vbar - 1
     shape1_start <- xbar * C
     shape2_start <- (1 - xbar) * C
-    MLEstart <- c(shape1_start, shape2_start)
+    MLE <- matrix(c(shape1_start, shape2_start), nrow = 2, ncol = 1, byrow = TRUE)
     rm(xbar, vbar, C, shape1_start, shape2_start)
 
-    MLEs <- stats::optim(MLEstart, neg_log_likelihood, lower = .Machine$double.eps, method = "L-BFGS-B", control = list(factr = 1e4))$par
-    return(MLEs)
+    # newtons method
+    # page 9
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      g1 <- base::digamma(MLE[1]) - base::digamma(MLE[1] + MLE[2]) - sum(log(x)) / length(x) # eq 2.6
+      g2 <- base::digamma(MLE[2]) - base::digamma(MLE[1] + MLE[2]) - sum(log(1 - x)) / length(x) # eq 2.7
+      g <- matrix(c(g1, g2), nrow = 2, ncol = 1, byrow = TRUE)
+
+      dg1dshape1 <- base::trigamma(MLE[1]) - base::trigamma(MLE[1] + MLE[2]) # eq 2.8
+      dg1dshape2 <- -1 * base::trigamma(MLE[1] + MLE[2]) # eq 2.9
+      dg2dshape2 <- base::trigamma(MLE[2]) - base::trigamma(MLE[1] + MLE[2]) # eq 2.10
+      G <- matrix(c(dg1dshape1, dg1dshape2, dg1dshape2, dg2dshape2), nrow = 2, ncol = 2, byrow = TRUE)
+
+      MLE_new <- MLE - solve(G) %*% g
+      tol <- max(abs(MLE - MLE_new))
+      counter <- counter + 1
+      MLE <- MLE_new
+    }
+
+    MLE <- as.vector(MLE)
+    return(MLE)
   }
   MLEs <- get_MLEs(x)
   obs_shape1 <- MLEs[1]
@@ -264,26 +297,37 @@ beta_shape1_one_way <- create_test_function_one_way_case_one(LRTesteR:::calc_tes
 calc_test_stat_beta_shape2_one_way <- function(x, fctr) {
   # null
   get_MLEs <- function(x) {
-    neg_log_likelihood <- function(MLEs) {
-      est_shape1 <- pmax(MLEs[1], .0001)
-      est_shape2 <- pmax(MLEs[2], .0001)
-
-      objective <- -1 * sum(stats::dbeta(x = x, shape1 = est_shape1, shape2 = est_shape2, log = TRUE))
-
-      return(objective)
-    }
-
     # starting points (method of moments)
     xbar <- base::mean(x)
     vbar <- stats::var(x)
     C <- (xbar * (1 - xbar)) / vbar - 1
     shape1_start <- xbar * C
     shape2_start <- (1 - xbar) * C
-    MLEstart <- c(shape1_start, shape2_start)
+    MLE <- matrix(c(shape1_start, shape2_start), nrow = 2, ncol = 1, byrow = TRUE)
     rm(xbar, vbar, C, shape1_start, shape2_start)
 
-    MLEs <- stats::optim(MLEstart, neg_log_likelihood, lower = .Machine$double.eps, method = "L-BFGS-B", control = list(factr = 1e4))$par
-    return(MLEs)
+    # newtons method
+    # page 9
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      g1 <- base::digamma(MLE[1]) - base::digamma(MLE[1] + MLE[2]) - sum(log(x)) / length(x) # eq 2.6
+      g2 <- base::digamma(MLE[2]) - base::digamma(MLE[1] + MLE[2]) - sum(log(1 - x)) / length(x) # eq 2.7
+      g <- matrix(c(g1, g2), nrow = 2, ncol = 1, byrow = TRUE)
+
+      dg1dshape1 <- base::trigamma(MLE[1]) - base::trigamma(MLE[1] + MLE[2]) # eq 2.8
+      dg1dshape2 <- -1 * base::trigamma(MLE[1] + MLE[2]) # eq 2.9
+      dg2dshape2 <- base::trigamma(MLE[2]) - base::trigamma(MLE[1] + MLE[2]) # eq 2.10
+      G <- matrix(c(dg1dshape1, dg1dshape2, dg1dshape2, dg2dshape2), nrow = 2, ncol = 2, byrow = TRUE)
+
+      MLE_new <- MLE - solve(G) %*% g
+      tol <- max(abs(MLE - MLE_new))
+      counter <- counter + 1
+      MLE <- MLE_new
+    }
+
+    MLE <- as.vector(MLE)
+    return(MLE)
   }
   MLEs <- get_MLEs(x)
   obs_shape1 <- MLEs[1]

--- a/R/gamma_tests.R
+++ b/R/gamma_tests.R
@@ -7,8 +7,13 @@ calc_test_stat_gamma_shape <- function(x, shape, alternative) {
     shape <- (3 - s + ((s - 3)^2 + 24 * s)^.5) / (12 * s)
 
     # newton updates
-    for (i in 1:10) {
-      shape <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      shape_new <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+      tol <- max(abs(shape - shape_new))
+      counter <- counter + 1
+      shape <- shape_new
     }
 
     scale <- sum(x) / (shape * length(x))
@@ -68,8 +73,13 @@ calc_test_stat_gamma_scale <- function(x, scale, alternative) {
     shape <- (3 - s + ((s - 3)^2 + 24 * s)^.5) / (12 * s)
 
     # newton updates
-    for (i in 1:10) {
-      shape <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      shape_new <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+      tol <- max(abs(shape - shape_new))
+      counter <- counter + 1
+      shape <- shape_new
     }
 
     scale <- sum(x) / (shape * length(x))
@@ -142,8 +152,13 @@ calc_test_stat_gamma_rate <- function(x, rate, alternative) {
     shape <- (3 - s + ((s - 3)^2 + 24 * s)^.5) / (12 * s)
 
     # newton updates
-    for (i in 1:10) {
-      shape <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      shape_new <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+      tol <- max(abs(shape - shape_new))
+      counter <- counter + 1
+      shape <- shape_new
     }
 
     scale <- sum(x) / (shape * length(x))
@@ -218,8 +233,13 @@ calc_test_stat_gamma_shape_one_way <- function(x, fctr) {
     shape <- (3 - s + ((s - 3)^2 + 24 * s)^.5) / (12 * s)
 
     # newton updates
-    for (i in 1:10) {
-      shape <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      shape_new <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+      tol <- max(abs(shape - shape_new))
+      counter <- counter + 1
+      shape <- shape_new
     }
 
     scale <- sum(x) / (shape * length(x))
@@ -262,11 +282,16 @@ calc_test_stat_gamma_shape_one_way <- function(x, fctr) {
       s <- log(mean(tempX)) - mean(log(tempX))
       shape <- (3 - s + ((s - 3)^2 + 24 * s)^.5) / (12 * s)
       # newton updates
-      for (j in 1:10) {
-        shape <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+      tol <- 999
+      counter <- 0
+      while (tol > .00001 & counter <= 30) {
+        shape_new <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+        tol <- max(abs(shape - shape_new))
+        counter <- counter + 1
+        shape <- shape_new
       }
       shapes[i] <- shape
-      rm(j, shape)
+      rm(shape)
     }
 
     start <- c(obs_rate, shapes)
@@ -333,8 +358,13 @@ calc_test_stat_gamma_scale_one_way <- function(x, fctr) {
     shape <- (3 - s + ((s - 3)^2 + 24 * s)^.5) / (12 * s)
 
     # newton updates
-    for (i in 1:10) {
-      shape <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      shape_new <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+      tol <- max(abs(shape - shape_new))
+      counter <- counter + 1
+      shape <- shape_new
     }
 
     scale <- sum(x) / (shape * length(x))
@@ -432,8 +462,13 @@ calc_test_stat_gamma_rate_one_way <- function(x, fctr) {
     shape <- (3 - s + ((s - 3)^2 + 24 * s)^.5) / (12 * s)
 
     # newton updates
-    for (i in 1:10) {
-      shape <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+    tol <- 999
+    counter <- 0
+    while (tol > .00001 & counter <= 30) {
+      shape_new <- shape - (log(shape) - base::digamma(shape) - s) / ((1 / shape) - base::psigamma(shape, deriv = 1))
+      tol <- max(abs(shape - shape_new))
+      counter <- counter + 1
+      shape <- shape_new
     }
 
     scale <- sum(x) / (shape * length(x))


### PR DESCRIPTION
This pull request updates beta distribution tests to use newton's method instead of Broyden–Fletcher–Goldfarb–Shanno. Add a bit of logic to remove unneeded newton steps for gamma tests.