### PR TITLE
remove debian check with rhub

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,8 @@
 * Add _one_way tests.
 * Add one way vignette.
 * Add print method.
-* Change to newton's method in beta, gamma, and cauchy parameter estimation.
+* Change to newton's method in beta and gamma parameter estimation.
+* Better starting points in cauchy parameter estimation.
 * Add sources.
 
 # LRTesteR 0.2.1

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -4,7 +4,6 @@
 * R Release on ubuntu (github actions)
 * R devel on ubuntu (github actions)
 * R devel on windows (win-builder)
-* R devel on debian (rhub)
 
 ## R CMD check results
 


### PR DESCRIPTION
Rhub checking appears to be broken at the moment. Removing check from cran comments.