### PR TITLE
move EnvStats to imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: LRTesteR
 Title: Likelihood Ratio Tests and Confidence Intervals
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: person(given = "Greg",
                     family = "McMahan",
                     role = c("aut", "cre"),
@@ -14,12 +14,12 @@ Imports:
     stats,
     rlang,
     statmod,
-    stringr
+    stringr,
+    EnvStats
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Suggests: 
     covr,
-    EnvStats,
     testthat,
     lmtest,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# LRTesteR 1.2.1
+* Add package EnvStats to imports
+
 # LRTesteR 1.2.0
 * Handle edge case in one way empirical quantile likelihood test.
 * Handle edge case in one way empirical mu likelihood test.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -10,6 +10,4 @@
 0 errors | 0 warnings | 0 note
 
 ## Main updates
-* Address edge cases for empirical tests.
-* Reduce sample size needed per test.
-* Use estimation procedures from EnvStats package for gamma and beta distribution.
+* Add package envstats to imports in description


### PR DESCRIPTION
This PR moves the R package EnvStats to imports so that it is installed during install of LRTesteR. This causes beta and gamma functions to work out more seamlessly. 