### PR TITLE
Remove the dev version of R from cran comments

### DIFF
--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,8 +1,9 @@
 ## Test environments
-* R Release on windows (github actions)
 * R Release on macOS (github actions)
+* R Release on windows (github actions)
+* R Old release on ubuntu (github actions)
 * R Release on ubuntu (github actions)
-* R devel on ubuntu (github actions)
+* R Devel on ubuntu (github actions)
 
 ## R CMD check results
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -3,7 +3,6 @@
 * R Release on macOS (github actions)
 * R Release on ubuntu (github actions)
 * R devel on ubuntu (github actions)
-* R devel on windows (devtools)
 
 ## R CMD check results
 


### PR DESCRIPTION
This PR removes the development version of R on windows from cran comments because it appears to no longer work. 